### PR TITLE
Raise max TCP segment queue length

### DIFF
--- a/core-files/etc/sysctl.d/trident-core.conf
+++ b/core-files/etc/sysctl.d/trident-core.conf
@@ -45,6 +45,7 @@ net.inet.tcp.path_mtu_discovery=0 	# disable MTU discovery since most ICMP type 
 net.inet.tcp.rfc3042=0 		# disable limited transmit mechanism which can slow burst transmissions (default 1)
 net.inet.udp.blackhole=1 		# drop udp packets destined for closed sockets (default 0)
 net.inet.tcp.blackhole=2 		# drop tcp packets destined for closed ports (default 0)
+net.inet.tcp.reass.maxqueuelen=1448	# Relax the TCP reassembly queue length limit to improve performance in the event of packet loss or reordering.
 
 ## IPv6 Security
 # Disable Node info replies (default 3)


### PR DESCRIPTION
Out-of-order TCP segments are queued in the reassembly queue until the missing in-sequence segments arrive.  As a DoS mitigation, the length of this queue is limited, with a default of 100.  Since TCP allows a whole window to be in-flight at once, there can be up to 1448 to 11586 segments arriving before the sender expects an ACK, depending on the configured max receive buffer size and negotiated window size.  The limit of 100 is not usually an issue in wired networks, because segments seldom arrive out of order.  However, reordering and/or losses are more frequent with wireless networks and more complex networks, so the low default limit can cause a lot of segments to be discarded.

Raise the limit to 1448, which allows a full window to be queued in the default configuration.

See following ticket: https://redmine.ixsystems.com/issues/43558