### PR TITLE
remove permissions for trueos-update

### DIFF
--- a/core-files/usr/local/etc/sudoers.d/trident
+++ b/core-files/usr/local/etc/sudoers.d/trident
@@ -28,6 +28,3 @@ Defaults env_keep += "XMODIFIERS GTK_IM_MODULE QT_IM_MODULE QT_IM_SWITCHER"
 # Allow passwordless access to run life preserver (wheel group only)
 %wheel ALL = NOPASSWD: /usr/local/bin/life-preserver
 
-# Allow passwordless access to run trueos-update (wheel/operator groups only)
-%wheel ALL = NOPASSWD: /usr/sbin/trueos-update
-%operator ALL = NOPASSWD: /usr/sbin/trueos-update


### PR DESCRIPTION
`trueos-update` is not part of the update process anymore, hence I removed the lines. I still hope for a future version of life-preserver so this line is still in.