### PR TITLE
allow searches for packages without root

### DIFF
--- a/core-files/usr/local/etc/sudoers.d/trident
+++ b/core-files/usr/local/etc/sudoers.d/trident
@@ -28,3 +28,5 @@ Defaults env_keep += "XMODIFIERS GTK_IM_MODULE QT_IM_MODULE QT_IM_SWITCHER"
 # Allow passwordless access to run life preserver (wheel group only)
 %wheel ALL = NOPASSWD: /usr/local/bin/life-preserver
 
+# Allow passwordless access to search for packages (install still requires password)
+%wheel ALL = NOPASSWD: /bin/xbps-query


### PR DESCRIPTION
**Installing packages still requires root**, however simply searching to see if a package is available from the CLI does not impact the system in anyway, so I fail to see why it should be protected by root.  A non root user can search online at https://voidlinux.org/packages/, so there's no reason they shouldn't be able to from the CLI.