### PR TITLE
Includes extra file with possible custom firewall rules.

### DIFF
--- a/void-files/etc/firewall-conf/custom-inbound.conf
+++ b/void-files/etc/firewall-conf/custom-inbound.conf
@@ -1,0 +1,12 @@
+# custom nftables ruleset
+# This file is included from /etc/firewall-conf/open-out.conf
+# and contains custom firewall rules for inbound traffic
+# rules can be added manually or by gui tools
+# Maintained by Project Trident: https://project-trident.org
+
+# uncomment to allow inbound ssh connections
+#add rule inet filter input tcp dport 22 accept
+
+# uncomment to allow inbound syncthing connections
+#add rule inet filter input tcp dport 22000 accept
+#add rule inet filter input udp dport 21027 accept

--- a/void-files/etc/firewall-conf/open-out.conf
+++ b/void-files/etc/firewall-conf/open-out.conf
@@ -15,5 +15,7 @@ add rule inet filter input iif lo accept
 add rule inet filter input ct state established,related accept
 # IPv6 neighbor discovery
 add rule inet filter input ip6 nexthdr icmpv6 icmpv6 type { nd-neighbor-solicit, echo-request, nd-router-advert, nd-neighbor-advert } accept
+# include file with custum inbound rules
+include custom-inbound.conf
 # drop all other packets
 add rule inet filter input counter drop


### PR DESCRIPTION
This way users can add their own rules by hand or maybe later with
a gui tool without fearing that their changes will be overwritten
by future updates of the nftable or a TridentOS package.
This extra file must still be included in the installer.